### PR TITLE
Typo in the port forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(2) do |config|
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 80, host: 80
+  config.vm.network "forwarded_port", guest: 80, host: 8080
   #config.vm.network "forwarded_port", guest: 9001, host: 9000
 
   # Create a private network, which allows host-only access to the machine


### PR DESCRIPTION
I Changed guest port to 8080, because there is an example in the docs with 8080 port, but config do not match with this example.
On most computers some application is already listening on this port. I think, it is better to use 8080 by default.

I have got an error with this config before I replaced port:

`Vagrant cannot forward the specified ports on this VM, since they
would collide with some other application that is already listening
on these ports. The forwarded port to 80 is already in use
on the host machine.
`
