### PR TITLE
Не были прописаны права на папки

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(2) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder ".", "/home/bitrix/www"
+  config.vm.synced_folder ".", "/home/bitrix/www", :mount_options => ["dmode=777", "fmode=666"]
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
Автор забыл указать права при монтировании, что вызывало ошибку прав записи (по крайней мере на Mac OS X)
